### PR TITLE
HOT FIX for missing `ZixiGan` in function `verifyMotto`

### DIFF
--- a/dplc/motto/motto.py
+++ b/dplc/motto/motto.py
@@ -22,6 +22,8 @@ def verifyMotto(P: argparse.Namespace):
         is_verified = verifyMottoJijieZou(motto)
     elif name == "QiangqiangGu":
         is_verified = verifyMottoQiangqiangGu(motto)
+    elif name == "ZixiGan":
+        is_verified = verifyMottoZixiGan(motto)
     else:
         assert RuntimeError("Your input name is not valid for this test!")
 


### PR DESCRIPTION
In respond to issue https://github.com/QG-phy/AlgorithmEngineering/issues/10

- add back name `ZixiGan` in `dplc.motto.motto.verifyMotto`